### PR TITLE
Set output file in CI/CD

### DIFF
--- a/.github/actions/build-zip-lint/action.yml
+++ b/.github/actions/build-zip-lint/action.yml
@@ -10,6 +10,7 @@ inputs:
 outputs:
   zipFile:
     description: "The path to the zip file"
+    value: ${{ steps.zip-output.outputs.zipFile }}
 
 runs:
   using: "composite"


### PR DESCRIPTION
Fixes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration to expose zip file path as an output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->