### PR TITLE
Fix hardcoded project name in action.yml

### DIFF
--- a/.github/actions/build-zip-lint/action.yml
+++ b/.github/actions/build-zip-lint/action.yml
@@ -35,7 +35,7 @@ runs:
     - name: Build the application for ${{ inputs.architecture }}
       shell: pwsh
       run: |
-        dotnet publish .\src\Community.PowerToys.Run.Plugin.CrcLauncher.csproj -c Release /p:PublishProfile=${{ inputs.architecture }}
+        dotnet publish .\src\${{ env.ProjectName }}.csproj -c Release /p:PublishProfile=${{ inputs.architecture }}
 
     - name: Clean and Zip the build output
       id: zip-output


### PR DESCRIPTION
Fixes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to use a dynamic project name reference via environment variable
	- Improved build process flexibility for project publishing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->